### PR TITLE
Layout and property updates

### DIFF
--- a/DKTabPageViewController/DKTabPageViewController.h
+++ b/DKTabPageViewController/DKTabPageViewController.h
@@ -87,7 +87,7 @@ typedef void(^TabPageBarAnimationBlock)(DKTabPageViewController *weakTabPageView
 - (instancetype)initWithItems:(NSArray *)items;
 
 @property (nonatomic, readonly) DKTabPageBar *tabPageBar;
-@property (nonatomic, readonly) NSArray *items;
+@property (nonatomic, copy, readonly) NSArray *items;
 @property (nonatomic, assign) NSInteger selectedIndex;
 @property (nonatomic, readonly) UIViewController *selectedViewController;
 

--- a/DKTabPageViewController/DKTabPageViewController.m
+++ b/DKTabPageViewController/DKTabPageViewController.m
@@ -727,6 +727,7 @@ CGSize dktabpage_getTextSize(UIFont *font,NSString *text, CGFloat maxWidth){
         [self setSelectedIndexByIndex:newIndex];
         [self didChangeValueForKey:NSStringFromSelector(@selector(selectedIndex))];
     }
+    [self cleanupSubviews];
 }
 
 @end

--- a/DKTabPageViewController/DKTabPageViewController.m
+++ b/DKTabPageViewController/DKTabPageViewController.m
@@ -545,6 +545,7 @@ CGSize dktabpage_getTextSize(UIFont *font,NSString *text, CGFloat maxWidth){
         _mainScrollView.alwaysBounceVertical = NO;
         _mainScrollView.directionalLockEnabled = YES;
         _mainScrollView.backgroundColor = [UIColor clearColor];
+        _mainScrollView.delaysContentTouches = NO;
     }
     return _mainScrollView;
 }

--- a/DKTabPageViewController/DKTabPageViewController.m
+++ b/DKTabPageViewController/DKTabPageViewController.m
@@ -369,7 +369,7 @@ CGSize dktabpage_getTextSize(UIFont *font,NSString *text, CGFloat maxWidth){
 
 @interface DKTabPageViewController () <UIScrollViewDelegate>
 
-@property (nonatomic, strong) NSArray *items;
+@property (nonatomic, copy, readwrite) NSArray *items;
 @property (nonatomic, strong) UIScrollView *mainScrollView;
 @property (nonatomic, strong) DKTabPageBar *tabPageBar;
 @property (nonatomic, assign) UIEdgeInsets scrollViewContentInsets;


### PR DESCRIPTION
- Clean up subviews (remove non-visible from superview) upon deceleration ended. Without this, there was a possibility of a tab's view being on the stack, with all constraints removed.
- Publicly exposes `items` array as readonly to allow consumers to determine number tabs. Also guards against switching tabs with an out of bounds index.
- Don't reset view's y-constraint when a tab child is a scrollview. This was causing child views to be inset under the navigation bar
- Don't delay content touches in the paged, `mainScrollView` was interferring with gestures on child views